### PR TITLE
Trim whitespace from IP address inputs to prevent SSH connection failures

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
@@ -112,7 +112,7 @@ export const HandleServers = ({ serverId }: Props) => {
 		await mutateAsync({
 			name: data.name,
 			description: data.description || "",
-			ipAddress: data.ipAddress || "",
+			ipAddress: data.ipAddress?.trim() || "",
 			port: data.port || 22,
 			username: data.username || "root",
 			sshKeyId: data.sshKeyId || "",

--- a/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
@@ -91,7 +91,7 @@ export const CreateServer = ({ stepper }: Props) => {
 		await mutateAsync({
 			name: data.name,
 			description: data.description || "",
-			ipAddress: data.ipAddress || "",
+			ipAddress: data.ipAddress?.trim() || "",
 			port: data.port || 22,
 			username: data.username || "root",
 			sshKeyId: data.sshKeyId || "",

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
@@ -33,7 +33,7 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 const schema = z.object({
-	serverIp: z.string(),
+	serverIp: z.string().trim(),
 });
 
 type Schema = z.infer<typeof schema>;
@@ -76,7 +76,7 @@ export const UpdateServerIp = ({ children }: Props) => {
 
 	const onSubmit = async (data: Schema) => {
 		await mutateAsync({
-			serverIp: data.serverIp,
+			serverIp: data.serverIp.trim(),
 		})
 			.then(async () => {
 				toast.success("Server IP Updated");

--- a/packages/server/src/db/schema/server.ts
+++ b/packages/server/src/db/schema/server.ts
@@ -121,6 +121,7 @@ const createSchema = createInsertSchema(server, {
 	serverId: z.string().min(1),
 	name: z.string().min(1),
 	description: z.string().optional(),
+	ipAddress: z.string().trim(),
 });
 
 export const apiCreateServer = createSchema


### PR DESCRIPTION
Implement trimming of whitespace from IP address fields across various components to resolve SSH connection issues caused by leading or trailing spaces. This change enhances user experience by allowing IP addresses with whitespace to be processed correctly. Fixes issue #10.