### PR TITLE
Fix #6 : Password visible in plaintext in app security view

### DIFF
--- a/README-issue6.md
+++ b/README-issue6.md
@@ -1,0 +1,141 @@
+# Issue 6: Security Password Visibility Bug
+
+## Bug Description
+In the App > Advanced > Security view, basic authentication passwords are displayed in plain text instead of being hidden behind visibility toggles, creating security risks and inconsistent UX.
+
+## Current vs Expected Behavior
+- **Current:** Password visible as plain text
+- **Expected:** Password hidden by default with toggle visibility + copy functionality
+
+## Breakdown into 2 Issues
+
+### Issue 1: Password Input Field in Security Form (Create/Edit Dialog)
+**Priority:** High - Affects credential creation/editing
+
+### Issue 2: Password Display in Security List View  
+**Priority:** High - Affects credential viewing
+
+---
+
+## Issue 1 Deep Dive
+
+### Location & Affected Code
+**File:** `apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx`  
+**Lines:** 147-160
+
+### Problem Code
+```tsx
+<FormField
+    control={form.control}
+    name="password"
+    render={({ field }) => (
+        <FormItem>
+            <FormLabel>Password</FormLabel>
+            <FormControl>
+                <Input placeholder="test" {...field} />  // ❌ Plain text input
+            </FormControl>
+            <FormMessage />
+        </FormItem>
+    )}
+/>
+```
+
+### Root Cause
+- Using basic `<Input>` component without password protection
+- Missing `type="password"` attribute
+- No visibility toggle functionality
+
+### Solution Approach
+Replace `<Input>` with existing `<ToggleVisibilityInput>` component that provides:
+- Hidden password by default (dots/asterisks)
+- Eye icon toggle to show/hide
+- Copy-to-clipboard functionality
+
+### Files to Modify
+1. `handle-security.tsx` - Add import and replace Input component
+
+### Required Changes
+```tsx
+// Add import (line 20)
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+
+// Replace Input with ToggleVisibilityInput (line 154)
+<ToggleVisibilityInput placeholder="test" {...field} />
+```
+
+### Testing Steps
+1. Navigate to App > Advanced > Security
+2. Click "Add Security" button
+3. **Verify:** Password field shows dots (••••) by default
+4. **Verify:** Click eye icon reveals password
+5. **Verify:** Click eye again hides password  
+6. **Verify:** Click copy icon copies password to clipboard
+7. **Verify:** Form submission works correctly
+
+### Success Criteria
+- Password hidden by default
+- Toggle visibility works
+- Copy functionality works
+- Form validation unchanged
+- Consistent with other password fields in app
+
+---
+
+## New Bug Discovered: Form Submission Issue
+
+### Bug Description
+After implementing the fix, clicking the eye icon or copy button in `ToggleVisibilityInput` submits the form instead of toggling visibility or copying to clipboard.
+
+### Root Cause
+HTML buttons inside `<form>` elements default to `type="submit"`. The `ToggleVisibilityInput` component buttons are missing `type="button"` attribute.
+
+### Fix Plan
+Add `type="button"` to both buttons in `ToggleVisibilityInput` component:
+```tsx
+<Button type="button" onClick={togglePasswordVisibility} variant={"secondary"}>
+<Button type="button" onClick={copyToClipboard} variant={"secondary"}>
+```
+
+### Files to Modify
+- `apps/dokploy/components/shared/toggle-visibility-input.tsx` (lines 20, 29)
+
+---
+
+## Impact Analysis: Features Using ToggleVisibilityInput
+
+### Currently Used In (11 locations):
+1. **Application Security Form** - ❌ AFFECTED (inside form)
+2. **Redis Internal Credentials** - ✅ Safe (display-only)
+3. **Redis External Credentials** - ✅ Safe (display-only)
+4. **PostgreSQL Internal Credentials** - ✅ Safe (display-only)
+5. **PostgreSQL External Credentials** - ✅ Safe (display-only)
+6. **MySQL Internal Credentials** - ✅ Safe (display-only)
+7. **MySQL External Credentials** - ✅ Safe (display-only)
+8. **MongoDB Internal Credentials** - ✅ Safe (display-only)
+9. **MongoDB External Credentials** - ✅ Safe (display-only)
+10. **MariaDB Internal Credentials** - ✅ Safe (display-only)
+11. **MariaDB External Credentials** - ✅ Safe (display-only)
+
+### Why Fix is Safe
+- **10/11 usages** are display-only views (not inside forms)
+- Only **1 usage** (Security form) is inside a form and affected
+- Adding `type="button"` makes buttons safer for future form usage
+- No breaking changes to existing display views
+
+---
+
+## Regression Testing Steps
+
+### High Priority (Security Form)
+1. Navigate to App > Advanced > Security
+2. Click "Add Security" or edit existing
+3. **Verify:** Eye icon toggles visibility (doesn't submit form)
+4. **Verify:** Copy icon copies to clipboard (doesn't submit form)
+5. **Verify:** Only "Update/Create" button submits form
+
+### Low Priority (Database Credential Views)
+1. Navigate to any database (Postgres/MySQL/MariaDB/MongoDB/Redis)
+2. Go to General tab > Credentials section
+3. **Verify:** Eye icon still toggles password visibility
+4. **Verify:** Copy icon still copies to clipboard
+5. **Verify:** No unexpected behavior changes

--- a/README-issue6.md
+++ b/README-issue6.md
@@ -139,3 +139,93 @@ Add `type="button"` to both buttons in `ToggleVisibilityInput` component:
 3. **Verify:** Eye icon still toggles password visibility
 4. **Verify:** Copy icon still copies to clipboard
 5. **Verify:** No unexpected behavior changes
+
+---
+
+## Issue 2 Deep Dive: Password Display in Security List View
+
+### Location & Affected Code
+**File:** `apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx`  
+**Lines:** 69-74
+
+### Problem Code
+```tsx
+<div className="flex flex-col gap-1">
+    <span className="font-medium">Password</span>
+    <span className="text-sm text-muted-foreground">
+        {security.password}  // ❌ Plain text display
+    </span>
+</div>
+```
+
+### Root Cause
+- Using plain `<span>` element to display password
+- No visibility toggle or copy functionality
+- Password exposed as plain text in the credentials list view
+
+### Solution Approach
+Replace `<span>` with `ToggleVisibilityInput` component using `disabled` prop:
+- Hidden password by default (dots/asterisks)
+- Eye icon toggle to show/hide
+- Copy-to-clipboard functionality
+- Read-only mode (can't edit, only view/copy)
+
+### Files to Modify
+1. `show-security.tsx` - Add import and replace span with ToggleVisibilityInput
+
+### Required Changes
+```tsx
+// Add import (line 1)
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+
+// Replace span with ToggleVisibilityInput (lines 69-74)
+<div className="flex flex-col gap-1">
+    <span className="font-medium">Password</span>
+    <ToggleVisibilityInput 
+        value={security.password}
+        disabled
+    />
+</div>
+```
+
+### Consistency with Other Features
+This fix follows the **exact same pattern** used in database credential views:
+
+**MySQL credentials example:**
+```tsx
+<ToggleVisibilityInput
+    disabled
+    value={data?.databasePassword}
+/>
+```
+
+**Security password display (after fix):**
+```tsx
+<ToggleVisibilityInput 
+    value={security.password}
+    disabled
+/>
+```
+
+Both use:
+- Same `ToggleVisibilityInput` component
+- Same `disabled` prop for read-only display
+- Same `value` prop for the password data
+- Same security features (toggle visibility + copy)
+
+### Testing Steps
+1. Navigate to App > Advanced > Security
+2. Ensure at least one security credential exists (create one if needed)
+3. **Verify:** Password shows as dots (••••) by default
+4. **Verify:** Click eye icon reveals password text
+5. **Verify:** Click eye icon again hides password back to dots
+6. **Verify:** Click copy icon copies password to clipboard with success toast
+7. **Verify:** Input is disabled (can't type/edit)
+8. **Verify:** Username field remains unchanged (plain text display)
+
+### Success Criteria
+- Password hidden by default in list view
+- Toggle visibility works for existing credentials
+- Copy functionality works for existing credentials
+- Consistent with database credential display patterns
+- No impact on edit functionality (handled separately in Issue 1)

--- a/SECURITY-PASSWORD-BEST-PRACTICES.md
+++ b/SECURITY-PASSWORD-BEST-PRACTICES.md
@@ -1,0 +1,317 @@
+# Password Security Best Practices in Software Development
+
+## Overview
+This document outlines industry standards and best practices for handling different types of passwords and credentials in software applications.
+
+---
+
+## 🔐 Two Main Categories of Passwords
+
+### 1. User Authentication Passwords
+**Definition:** Passwords that humans use to log into applications  
+**Security Level:** CRITICAL - Must be hashed  
+**Examples:** User login, admin accounts, personal passwords
+
+### 2. Service/System Credentials
+**Definition:** Credentials used for service-to-service communication  
+**Security Level:** HIGH - Should be encrypted or managed securely  
+**Examples:** API keys, database passwords, HTTP Basic Auth, service tokens
+
+---
+
+## ✅ User Authentication Passwords - ALWAYS HASH
+
+### Industry Standard: Never Store Plain Text
+```typescript
+// ❌ NEVER DO THIS
+const user = {
+  email: "user@example.com",
+  password: "plaintextPassword123"  // SECURITY VIOLATION!
+}
+
+// ✅ CORRECT APPROACH
+const user = {
+  email: "user@example.com",
+  passwordHash: await bcrypt.hash("plaintextPassword123", 12)
+}
+```
+
+### Recommended Hashing Algorithms
+1. **bcrypt** (Most Popular)
+   ```typescript
+   import bcrypt from 'bcrypt'
+   const hash = await bcrypt.hash(password, 12)
+   const isValid = await bcrypt.compare(password, hash)
+   ```
+
+2. **Argon2** (Newer, More Secure)
+   ```typescript
+   import argon2 from 'argon2'
+   const hash = await argon2.hash(password)
+   const isValid = await argon2.verify(hash, password)
+   ```
+
+3. **scrypt** (Good Alternative)
+   ```typescript
+   import scrypt from 'scrypt'
+   const hash = await scrypt.hash(password, salt)
+   ```
+
+### Why Hash User Passwords?
+- **Irreversible:** Cannot recover original password
+- **Breach Protection:** Even if database is compromised
+- **Industry Compliance:** Required by security standards
+- **User Privacy:** Users can't be impersonated easily
+
+---
+
+## ⚠️ Service Credentials - Encrypt When Possible
+
+### Common Service Credential Types
+```typescript
+// HTTP Basic Auth (like Dokploy's case)
+const basicAuth = {
+  username: "admin",
+  password: "servicePassword123"  // Often stored as-is
+}
+
+// Database Connection
+const dbConfig = {
+  host: "localhost",
+  username: "dbuser", 
+  password: "dbPassword123"  // Should be encrypted
+}
+
+// API Keys
+const apiConfig = {
+  apiKey: "sk-1234567890abcdef",  // Should be encrypted
+  secretKey: "secret123"
+}
+```
+
+### Why Service Credentials Are Different
+- **Retrievability Required:** Systems need the actual value
+- **Service-to-Service:** Not human authentication
+- **Configuration Data:** Used to configure external services
+- **Often Required in Plain Text:** By the consuming service
+
+---
+
+## 🛡️ Best Practices for Service Credentials
+
+### 1. Encrypted Storage (Recommended)
+```typescript
+// Store encrypted in database
+const encryptedPassword = encrypt(plainPassword, masterKey)
+
+// Decrypt only when needed
+const plainPassword = decrypt(encryptedPassword, masterKey)
+```
+
+### 2. Environment Variables
+```bash
+# Don't store in database at all
+BASIC_AUTH_USERNAME=admin
+BASIC_AUTH_PASSWORD=mySecretPassword123
+API_KEY=sk-1234567890abcdef
+```
+
+### 3. Secret Management Systems
+```typescript
+// HashiCorp Vault
+const secret = await vault.read('secret/myapp/credentials')
+
+// AWS Secrets Manager
+const secret = await secretsManager.getSecretValue({
+  SecretId: 'myapp/basic-auth'
+})
+
+// Kubernetes Secrets
+const secret = await k8sApi.readNamespacedSecret('my-secret', 'default')
+```
+
+### 4. Configuration Management
+```typescript
+// Docker Compose with external secrets
+services:
+  app:
+    environment:
+      - BASIC_AUTH_USERNAME_FILE=/run/secrets/basic_auth_username
+      - BASIC_AUTH_PASSWORD_FILE=/run/secrets/basic_auth_password
+```
+
+---
+
+## 📊 Industry Examples by Technology
+
+### Web Applications
+```typescript
+// User passwords: ALWAYS hash
+const userPassword = await bcrypt.hash(inputPassword, 12)
+
+// API keys: Encrypt or use secret management
+const apiKey = encrypt(plainApiKey, encryptionKey)
+```
+
+### Microservices
+```typescript
+// Service-to-service: Use tokens, not passwords
+const serviceToken = await generateJWT({
+  serviceId: 'user-service',
+  permissions: ['read:users']
+})
+```
+
+### Container Orchestration
+```yaml
+# Kubernetes - Base64 encoded (not encrypted!)
+apiVersion: v1
+kind: Secret
+type: Opaque
+data:
+  username: YWRtaW4=  # admin (base64)
+  password: cGFzc3dvcmQ=  # password (base64)
+```
+
+### Infrastructure as Code
+```hcl
+# Terraform with AWS Secrets Manager
+resource "aws_secretsmanager_secret" "app_credentials" {
+  name = "my-app/credentials"
+  description = "Application credentials"
+}
+```
+
+---
+
+## 🎯 Dokploy's Current Approach Analysis
+
+### What Dokploy Does (Basic Auth Credentials)
+```typescript
+// HTTP Basic Auth for Traefik/nginx
+const security = {
+  username: "admin",
+  password: "mySecretPassword123"  // Stored in database
+}
+```
+
+### Security Assessment
+- ✅ **Good:** Passwords hidden in UI (your recent fix)
+- ✅ **Good:** Not logged in application logs
+- ⚠️ **Questionable:** Stored in plain text in database
+- ✅ **Good:** Access controlled through application permissions
+
+### Industry Comparison
+- **Similar to:** Docker Compose, many CI/CD tools, basic web apps
+- **Better than:** Applications that log credentials
+- **Worse than:** Secret management systems (Vault, AWS Secrets Manager)
+
+---
+
+## 🚀 Recommended Improvements for Dokploy
+
+### Short Term (Easy Wins)
+1. **UI Security** ✅ (Already implemented)
+   - Hide passwords in display
+   - Add copy-to-clipboard functionality
+   - Prevent accidental exposure
+
+2. **Audit Logging**
+   ```typescript
+   // Log when credentials are accessed
+   auditLog.info('Security credentials viewed', {
+     userId: user.id,
+     securityId: security.securityId,
+     action: 'view'
+   })
+   ```
+
+3. **Database Encryption at Rest**
+   ```sql
+   -- Ensure database encryption is enabled
+   ALTER DATABASE dokploy_db ENCRYPTION = 'Y';
+   ```
+
+### Medium Term (Better Security)
+1. **Encrypt Credentials in Database**
+   ```typescript
+   // Before storing
+   const encryptedPassword = encrypt(password, masterKey)
+   
+   // When retrieving
+   const decryptedPassword = decrypt(encryptedPassword, masterKey)
+   ```
+
+2. **Secret Rotation**
+   ```typescript
+   // Allow users to rotate credentials
+   const newCredentials = generateSecureCredentials()
+   await updateSecurityCredentials(securityId, newCredentials)
+   ```
+
+### Long Term (Enterprise Grade)
+1. **External Secret Management**
+   ```typescript
+   // Integrate with HashiCorp Vault
+   const credentials = await vault.read('secret/dokploy/basic-auth')
+   ```
+
+2. **Zero-Knowledge Architecture**
+   - Application never sees plain text passwords
+   - Direct integration with secret management
+   - Automatic rotation and lifecycle management
+
+---
+
+## 🔍 Security Considerations by Use Case
+
+### High-Risk Scenarios
+- **Public/shared computers:** Always hide passwords in UI
+- **Screen sharing:** Implement timeout for credential views
+- **Audit requirements:** Log all credential access
+- **Compliance:** PCI-DSS, HIPAA, SOX requirements
+
+### Medium-Risk Scenarios
+- **Internal tools:** Basic encryption sufficient
+- **Development environments:** Environment variables OK
+- **Single-tenant applications:** Database encryption adequate
+
+### Low-Risk Scenarios
+- **Personal projects:** Basic hashing sufficient
+- **Proof of concepts:** Plain text storage acceptable (with warnings)
+
+---
+
+## 📚 Additional Resources
+
+### Security Standards
+- **OWASP Password Storage Cheat Sheet**
+- **NIST Special Publication 800-63B**
+- **PCI DSS Requirements**
+
+### Tools and Libraries
+- **HashiCorp Vault:** Enterprise secret management
+- **AWS Secrets Manager:** Cloud-native secret management
+- **Kubernetes Secrets:** Container orchestration secrets
+- **bcrypt, Argon2:** Password hashing libraries
+
+### Best Practices Summary
+1. **Hash user passwords** - Always, no exceptions
+2. **Encrypt service credentials** - When possible
+3. **Use secret management** - For production systems
+4. **Hide in UI** - Prevent accidental exposure
+5. **Audit access** - Log credential usage
+6. **Rotate regularly** - Implement credential lifecycle
+7. **Principle of least privilege** - Only expose when needed
+
+---
+
+## 💡 Key Takeaways
+
+1. **Context Matters:** User passwords vs service credentials have different requirements
+2. **Your UI Fix is Valuable:** Even if backend storage could be improved
+3. **Industry Trend:** Moving toward encrypted secret management
+4. **Risk Assessment:** Consider your threat model and compliance requirements
+5. **Gradual Improvement:** Start with UI security, move toward encryption
+
+Remember: **Perfect security is impossible, but good security is achievable through layered defenses.**

--- a/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
@@ -1,4 +1,5 @@
 import { AlertBlock } from "@/components/shared/alert-block";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -151,7 +152,7 @@ export const HandleSecurity = ({
 									<FormItem>
 										<FormLabel>Password</FormLabel>
 										<FormControl>
-											<Input placeholder="test" {...field} />
+											<ToggleVisibilityInput placeholder="test" {...field} />
 										</FormControl>
 
 										<FormMessage />

--- a/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
@@ -11,6 +11,7 @@ import { api } from "@/utils/api";
 import { LockKeyhole, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { HandleSecurity } from "./handle-security";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	applicationId: string;
@@ -68,9 +69,10 @@ export const ShowSecurity = ({ applicationId }: Props) => {
 											</div>
 											<div className="flex flex-col gap-1">
 												<span className="font-medium">Password</span>
-												<span className="text-sm text-muted-foreground">
-													{security.password}
-												</span>
+												<ToggleVisibilityInput
+													value={security.password}
+													disabled
+												/>
 											</div>
 										</div>
 										<div className="flex flex-row gap-2">

--- a/apps/dokploy/components/shared/toggle-visibility-input.tsx
+++ b/apps/dokploy/components/shared/toggle-visibility-input.tsx
@@ -18,6 +18,7 @@ export const ToggleVisibilityInput = ({ ...props }: InputProps) => {
 		<div className="flex w-full items-center space-x-2">
 			<Input ref={inputRef} type={inputType} {...props} />
 			<Button
+				type="button"
 				variant={"secondary"}
 				onClick={() => {
 					copy(inputRef.current?.value || "");
@@ -26,7 +27,7 @@ export const ToggleVisibilityInput = ({ ...props }: InputProps) => {
 			>
 				<Clipboard className="size-4 text-muted-foreground" />
 			</Button>
-			<Button onClick={togglePasswordVisibility} variant={"secondary"}>
+			<Button type="button" onClick={togglePasswordVisibility} variant={"secondary"}>
 				{inputType === "password" ? (
 					<EyeIcon className="size-4 text-muted-foreground" />
 				) : (


### PR DESCRIPTION
# Fixes #6 : [SECURITY] Password visible in plain text in App Security view

# Before:

https://github.com/user-attachments/assets/91b6c665-459b-4aa9-bd0e-67101b57ba56

# After: 

https://github.com/user-attachments/assets/b24aaed3-a8ea-47f1-acd2-251fdc40777a

# Regression testing:

https://github.com/user-attachments/assets/00daab80-7519-4e45-8b42-45641132efaf

# What Changed
- Replaced plain text <Input> with <ToggleVisibilityInput> in security form dialog
- Replaced plain text <span> with <ToggleVisibilityInput> in security credentials list view
- Component Fix: Added type="button" to ToggleVisibilityInput buttons to prevent form submission

Both now hide passwords by default with toggle visibility and copy functionality

# Why This Fix
- Security Risk: Passwords were displayed in plain text, visible to anyone viewing the screen
- Form Bug: Eye/copy buttons in forms were submitting instead of toggling (missing type="button")
- Inconsistent UX: Other password fields in the app already use ToggleVisibilityInput
- Industry Standard: Passwords should be hidden by default with secure viewing options

# Testing Done
✅ Security Form: Eye icon toggles visibility, copy button works, form submits correctly (no longer submits on button clicks)
✅ Security List View: Passwords hidden by default, toggle and copy functionality works
✅ Regression Testing: Verified eye/copy buttons still work on all database credential views (PostgreSQL, MySQL, MariaDB, MongoDB, Redis) - no impact on existing features

# Files Modified
- handle-security.tsx - Added ToggleVisibilityInput to form
- show-security.tsx - Added ToggleVisibilityInput to list view
- toggle-visibility-input.tsx - Added type="button" to prevent form submission
- README-issue6.md - Documentation of both issues and fixes