### PR TITLE
Added trim function on submit for the ipAddress to eliminate any lead…

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
@@ -112,13 +112,14 @@ export const HandleServers = ({ serverId }: Props) => {
 		await mutateAsync({
 			name: data.name,
 			description: data.description || "",
-			ipAddress: data.ipAddress || "",
+			ipAddress: data.ipAddress?.trim() || "",
 			port: data.port || 22,
 			username: data.username || "root",
 			sshKeyId: data.sshKeyId || "",
 			serverId: serverId || "",
 		})
 			.then(async (_data) => {
+				console.log("Trimmed IP Address")
 				await utils.server.all.invalidate();
 				refetchServer();
 				toast.success(serverId ? "Server Updated" : "Server Created");


### PR DESCRIPTION
Problem: 
Trailing white spaces when entering IP address for a remote server doesn't allow it to actually connect, and causes issues for the user. 

Here is a Mal formated remote server with leading white spaces
<img width="807" height="373" alt="image" src="https://github.com/user-attachments/assets/1211c56c-eca4-43f4-8518-b8f129ea1aee" />

it ends up failing when we try to ssh into it

<img width="810" height="369" alt="image" src="https://github.com/user-attachments/assets/7b3778db-c5f2-4960-a08c-487e17c01087" />


Our solution:

Add .trim() to the ip_address when it gets submited by the frontend. The video shows a walk through of a fixed version, and where we ended up changing the code.  https://cap.so/s/efqrfeyj84twtgb
